### PR TITLE
Adds Cookbook Name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             "chef-unzip"
+name             "unzip"
 maintainer       "Nathan Mische"
 maintainer_email "nmsiche@wharton.upenn.edu"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "chef-unzip"
 maintainer       "Nathan Mische"
 maintainer_email "nmsiche@wharton.upenn.edu"
 license          "Apache 2.0"


### PR DESCRIPTION
Turns out the latest version of Berkshelf/Vagrant requires a name attribute to avoid Ridley error
